### PR TITLE
Modify configureConnection to POST only

### DIFF
--- a/src/main/java/io/ipfs/api/IPFS.java
+++ b/src/main/java/io/ipfs/api/IPFS.java
@@ -75,7 +75,7 @@ public class IPFS {
             throw new RuntimeException(e);
         }
     }
-    
+
     /**
      * Configure a HTTP client timeout
      * @param timeout (default 0: infinite timeout)
@@ -676,7 +676,7 @@ public class IPFS {
     }
 
     private static byte[] get(URL target, int timeout) throws IOException {
-        HttpURLConnection conn = configureConnection(target, "GET", timeout);
+        HttpURLConnection conn = configureConnection(target, timeout);
 
         try {
             InputStream in = conn.getInputStream();
@@ -744,7 +744,7 @@ public class IPFS {
     }
 
     private static InputStream getStream(URL target, int timeout) throws IOException {
-        HttpURLConnection conn = configureConnection(target, "GET", timeout);
+        HttpURLConnection conn = configureConnection(target, timeout);
         return conn.getInputStream();
     }
 
@@ -754,7 +754,7 @@ public class IPFS {
     }
 
     private static byte[] post(URL target, byte[] body, Map<String, String> headers, int timeout) throws IOException {
-        HttpURLConnection conn = configureConnection(target, "POST", timeout);
+        HttpURLConnection conn = configureConnection(target, timeout);
         for (String key: headers.keySet())
             conn.setRequestProperty(key, headers.get(key));
         conn.setDoOutput(true);
@@ -775,7 +775,7 @@ public class IPFS {
             while ((r=in.read(buf)) >= 0)
                 resp.write(buf, 0, r);
             return resp.toByteArray();
-            
+
         } catch(IOException ex) {
             throw new RuntimeException("Error reading InputStrean", ex);
         }
@@ -784,10 +784,10 @@ public class IPFS {
     private static boolean detectSSL(MultiAddress multiaddress) {
         return multiaddress.toString().contains("/https");
     }
-    
-    private static HttpURLConnection configureConnection(URL target, String method, int timeout) throws IOException {
+
+    private static HttpURLConnection configureConnection(URL target, int timeout) throws IOException {
         HttpURLConnection conn = (HttpURLConnection) target.openConnection();
-        conn.setRequestMethod(method);
+        conn.setRequestMethod("POST");
         conn.setRequestProperty("Content-Type", "application/json");
         conn.setReadTimeout(timeout);
         return conn;


### PR DESCRIPTION
IPFS method does not support GET Method.
When i tried to initialize IPFS Object, it occurs an error like below

Exception in thread "main" java.lang.RuntimeException: IOException contacting IPFS daemon.
Trailer: null 405 - Method Not Allowed

	at io.ipfs.api.IPFS.get(IPFS.java:683)
	at io.ipfs.api.IPFS.retrieve(IPFS.java:662)
	at io.ipfs.api.IPFS.retrieveAndParse(IPFS.java:624)
	at io.ipfs.api.IPFS.version(IPFS.java:572)
	at io.ipfs.api.IPFS.<init>(IPFS.java:69)
	at io.ipfs.api.IPFS.<init>(IPFS.java:45)
	at Main.main(Main.java:15)
Caused by: java.io.IOException: Server returned HTTP response code: 405 for URL: http://127.0.0.1:5001/api/v0/version
	at sun.net.www.protocol.http.HttpURLConnection.getInputStream0(HttpURLConnection.java:1900)
	at sun.net.www.protocol.http.HttpURLConnection.getInputStream(HttpURLConnection.java:1498)
	at io.ipfs.api.IPFS.get(IPFS.java:671)
	... 6 more

So We have to modify all request to POST only