### PR TITLE
feat: support go-ipfs 0.5 and Java 10+

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,10 @@
 language: java
 jdk:
-  - oraclejdk8
+  - openjdk9
+  - openjdk10
+  - openjdk11
 before_script:
-  - wget https://dist.ipfs.io/go-ipfs/v0.4.16/go-ipfs_v0.4.16_linux-amd64.tar.gz -O /tmp/go-ipfs_linux-amd64.tar.gz
+  - wget https://dist.ipfs.io/go-ipfs/v0.5.1/go-ipfs_v0.5.1_linux-amd64.tar.gz -O /tmp/go-ipfs_linux-amd64.tar.gz
   - tar -xvf /tmp/go-ipfs_linux-amd64.tar.gz
   - export PATH=$PATH:$PWD/go-ipfs/
   - ipfs init

--- a/src/main/java/io/ipfs/api/IPFS.java
+++ b/src/main/java/io/ipfs/api/IPFS.java
@@ -75,7 +75,7 @@ public class IPFS {
             throw new RuntimeException(e);
         }
     }
-    
+
     /**
      * Configure a HTTP client timeout
      * @param timeout (default 0: infinite timeout)
@@ -676,7 +676,7 @@ public class IPFS {
     }
 
     private static byte[] get(URL target, int timeout) throws IOException {
-        HttpURLConnection conn = configureConnection(target, "GET", timeout);
+        HttpURLConnection conn = configureConnection(target, timeout);
 
         try {
             InputStream in = conn.getInputStream();
@@ -744,7 +744,7 @@ public class IPFS {
     }
 
     private static InputStream getStream(URL target, int timeout) throws IOException {
-        HttpURLConnection conn = configureConnection(target, "GET", timeout);
+        HttpURLConnection conn = configureConnection(target, timeout);
         return conn.getInputStream();
     }
 
@@ -754,7 +754,7 @@ public class IPFS {
     }
 
     private static byte[] post(URL target, byte[] body, Map<String, String> headers, int timeout) throws IOException {
-        HttpURLConnection conn = configureConnection(target, "POST", timeout);
+        HttpURLConnection conn = configureConnection(target, timeout);
         for (String key: headers.keySet())
             conn.setRequestProperty(key, headers.get(key));
         conn.setDoOutput(true);
@@ -775,7 +775,7 @@ public class IPFS {
             while ((r=in.read(buf)) >= 0)
                 resp.write(buf, 0, r);
             return resp.toByteArray();
-            
+
         } catch(IOException ex) {
             throw new RuntimeException("Error reading InputStrean", ex);
         }
@@ -784,10 +784,10 @@ public class IPFS {
     private static boolean detectSSL(MultiAddress multiaddress) {
         return multiaddress.toString().contains("/https");
     }
-    
-    private static HttpURLConnection configureConnection(URL target, String method, int timeout) throws IOException {
+
+    private static HttpURLConnection configureConnection(URL target, int timeout) throws IOException {
         HttpURLConnection conn = (HttpURLConnection) target.openConnection();
-        conn.setRequestMethod(method);
+        conn.setRequestMethod("POST");
         conn.setRequestProperty("Content-Type", "application/json");
         conn.setReadTimeout(timeout);
         return conn;


### PR DESCRIPTION
> This PR supersedes https://github.com/ipfs-shipyard/java-ipfs-http-client/pull/160 https://github.com/ipfs-shipyard/java-ipfs-http-client/pull/159 and https://github.com/ipfs-shipyard/java-ipfs-http-client/pull/161 


- close https://github.com/ipfs-shipyard/java-ipfs-http-client/issues/157 
- close https://github.com/ipfs-shipyard/java-ipfs-http-client/issues/163 
- close https://github.com/ipfs-shipyard/java-ipfs-http-client/issues/162


### TODO

Tests do not pass, looks like there is no support for CIDv1/multibase:

- [ ] `java.lang.IllegalStateException: Unknown Multibase type: b`
- [ ] `java.lang.IllegalStateException: Unknown Multihash type: 0`
- [ ]  update deps – #165