### PR TITLE
Better management of temporary files in RecursiveAddTest

### DIFF
--- a/src/test/java/io/ipfs/api/RecursiveAddTest.java
+++ b/src/test/java/io/ipfs/api/RecursiveAddTest.java
@@ -1,10 +1,14 @@
 package io.ipfs.api;
 
+import java.io.File;
 import java.nio.file.*;
 import java.util.*;
 
 import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
 
 import io.ipfs.multiaddr.MultiAddress;
 
@@ -12,7 +16,15 @@ public class RecursiveAddTest {
 
     private final IPFS ipfs = new IPFS(new MultiAddress("/ip4/127.0.0.1/tcp/5001"));
     
-    static Path TMPDATA = Paths.get("target/tmpdata");
+    static File TMPDATA = new File("target/tmpdata");
+
+    @BeforeClass
+    public static void createTmpData() {
+        TMPDATA.mkdirs();
+    }
+
+    @Rule
+    public TemporaryFolder tempFolder = new TemporaryFolder(TMPDATA);
     
     @Test
     public void testAdd() throws Exception {
@@ -20,7 +32,7 @@ public class RecursiveAddTest {
 
         String EXPECTED = "QmX5fZ6aUxNTAS7ZfYc8f4wPoMx6LctuNbMjuJZ9EmUSr6";
 
-        Path base = Files.createTempDirectory("test");
+        Path base = tempFolder.newFolder().toPath();
         Files.write(base.resolve("index.html"), "<html></html>".getBytes());
         Path js = base.resolve("js");
         js.toFile().mkdirs();
@@ -35,7 +47,7 @@ public class RecursiveAddTest {
     public void binaryRecursiveAdd() throws Exception {
         String EXPECTED = "Qmd1dTx4Z1PHxSHDR9jYoyLJTrYsAau7zLPE3kqo14s84d";
 
-        Path base = TMPDATA.resolve("bindata");
+        Path base = tempFolder.newFolder().toPath();
         base.toFile().mkdirs();
         byte[] bindata = new byte[1024*1024];
         new Random(28).nextBytes(bindata);
@@ -53,7 +65,7 @@ public class RecursiveAddTest {
     public void largeBinaryRecursiveAdd() throws Exception {
         String EXPECTED = "QmZdfdj7nfxE68fBPUWAGrffGL3sYGx1MDEozMg73uD2wj";
 
-        Path base = TMPDATA.resolve("largebindata");
+        Path base = tempFolder.newFolder().toPath();
         base.toFile().mkdirs();
         byte[] bindata = new byte[100 * 1024*1024];
         new Random(28).nextBytes(bindata);
@@ -73,7 +85,7 @@ public class RecursiveAddTest {
     public void largeBinaryInSubdirRecursiveAdd() throws Exception {
         String EXPECTED = "QmUYuMwCpgaxJhNxRA5Pmje8EfpEgU3eQSB9t3VngbxYJk";
 
-        Path base = TMPDATA.resolve("largebininsubdirdata");
+        Path base = tempFolder.newFolder().toPath();
         base.toFile().mkdirs();
         Path bindir = base.resolve("moredata");
         bindir.toFile().mkdirs();


### PR DESCRIPTION
The test used to create temporary files without cleaning them afterwards, which made subsequent runs always fail.

I have checked that the test [passes](https://github.com/odisseus/java-ipfs-fury/pull/5/checks?check_run_id=813597003#step:7:30) when all other dependency-related problems are fixed.