### PR TITLE
Restore support for Java 8

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -71,9 +71,8 @@
 				<artifactId>maven-compiler-plugin</artifactId>
 				<version>3.8.0</version>
 				<configuration>
-					<release>11</release>
-					<source>11</source>
-					<target>11</target>
+					<source>1.8</source>
+					<target>1.8</target>
 				</configuration>
 			</plugin>
 			<plugin>

--- a/src/test/java/io/ipfs/api/APITest.java
+++ b/src/test/java/io/ipfs/api/APITest.java
@@ -141,7 +141,7 @@ public class APITest {
         List<MerkleNode> lsResult = ipfs.ls(addResult.hash);
         if (lsResult.size() != 2)
             throw new IllegalStateException("Incorrect number of objects in ls!");
-        if (! lsResult.stream().map(x -> x.name.get()).collect(Collectors.toSet()).equals(Set.of(subdirName, fileName)))
+        if (! lsResult.stream().map(x -> x.name.get()).collect(Collectors.toSet()).equals(new HashSet<>(Arrays.asList(subdirName, fileName))))
             throw new IllegalStateException("Dir not returned in ls!");
         byte[] catResult = ipfs.cat(addResult.hash, "/" + fileName);
         if (! Arrays.equals(catResult, fileContents))


### PR DESCRIPTION
The recent 1.3.2 release raised target Java version from 8 to 11. However, some project I'm working on is still on Java 8, and I believe many existing projects out there are not ready to upgrade to 11 yet.

I find that the only place where Java 11 features were used was in the tests. This PR replaces them with Java 8 compatible implementation and reverts minimum required Java version to 8. Please consider staying compatible with Java 8 for a bit longer!
