### PR TITLE
chore: enable CI on PRs

### DIFF
--- a/.github/workflows/ant.yml
+++ b/.github/workflows/ant.yml
@@ -1,6 +1,6 @@
 name: Java CI
 
-on: [push]
+on: [push, pull_request]
 
 jobs:
   build:


### PR DESCRIPTION
I don't believe we have any secrets,  should be fine to enable tests on PRs provided by third party contributors, such as #172 

@ianopolous thoughts?