### PR TITLE
Set chunk size of 4096 for body streaming

### DIFF
--- a/src/main/java/io/ipfs/api/Multipart.java
+++ b/src/main/java/io/ipfs/api/Multipart.java
@@ -26,6 +26,7 @@ public class Multipart {
             httpConn.setRequestProperty("Expect", "100-continue");
             httpConn.setRequestProperty("Content-Type", "multipart/form-data; boundary=" + boundary);
             httpConn.setRequestProperty("User-Agent", "Java IPFS CLient");
+            httpConn.setChunkedStreamingMode(4096);
             out = httpConn.getOutputStream();
         } catch (IOException e) {
             throw new RuntimeException(e.getMessage(), e);


### PR DESCRIPTION
Per the discussion on the issue, this should be able to fix GH-72 (also fix GH-123 and fix GH-129), thus supersede and close GH-79.  As for @ianopolous' comment on the original patch

> This will help with large files, but I'd like to make it optional. So single file adds would only use it beyond a certain size, and dir adds would do the same, but for the total size of the subtree.

I second @Clay-Ferguson's comment on the original issue

> The streaming apis buffer sizes at the lower levels of networking system code all use 4096, so [...] everything lines up perfectly with no unnecessary buffering or waiting.

and therefore always streaming like this would not have noticeable performance impact.