### PR TITLE
Fix issue #191: IPFS.jar's timeout(int timeout) does not pass timeout to constructor

### DIFF
--- a/src/main/java/io/ipfs/api/IPFS.java
+++ b/src/main/java/io/ipfs/api/IPFS.java
@@ -93,7 +93,7 @@ public class IPFS {
      * @return current IPFS object with configured timeout
      */
     public IPFS timeout(int timeout) {
-        return new IPFS(host, port, version, connectTimeoutMillis, readTimeoutMillis, protocol.equals("https"));
+        return new IPFS(host, port, version, timeout, timeout, protocol.equals("https"));
     }
 
     public List<MerkleNode> add(NamedStreamable file) throws IOException {


### PR DESCRIPTION
im not sure if timeout is meant to be for connection or for read so i'm mainly committing this to see if it gets rejected with an explanation, so i can learn more about this project

it seems like this timeout is supposed to apply to both, considering there are 2 timeout variables but only 1 vague timeout can be passed in

this is related to https://github.com/ipfs-shipyard/java-ipfs-http-client/issues/191#issue-1088603402