### PR TITLE
docs: Clarify on README now to run tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ for Maven, add the following sections to your pom.xml (replacing $LATEST_VERSION
 
 ### Running tests
 
-To run tests, IPFS daemon must be running on `127.0.0.1` interface. 
+To run tests, IPFS daemon must be running on `127.0.0.1` interface, with `--enable-pubsub-experiment`, and without `--mount`. 
 
 ### IPFS installation
 


### PR DESCRIPTION
Kubo must run with `--enable-pubsub-experiment` & and without `--mount`.

@ianopolous merge?