### PR TITLE
build: Run CI once a week

### DIFF
--- a/.github/workflows/ant.yml
+++ b/.github/workflows/ant.yml
@@ -1,6 +1,10 @@
 name: Java CI
 
-on: [push, pull_request]
+on:
+  schedule:
+    - cron: '42 0 * * 4'
+  push:  
+  pull_request:
 
 jobs:
   build:


### PR DESCRIPTION
@ianopolous any objections to this?

It would catch any regressions introduced by external dependencies, and help contributors see if tests work on CI.