### PR TITLE
fix: Remove broken failing test of @Deprecated DNS method

### DIFF
--- a/src/main/java/io/ipfs/api/IPFS.java
+++ b/src/main/java/io/ipfs/api/IPFS.java
@@ -200,12 +200,6 @@ public class IPFS {
         return retrieveMap("resolve?arg=/" + scheme+"/"+hash +"&r="+recursive);
     }
 
-    @Deprecated
-    public String dns(String domain, boolean recursive) throws IOException {
-        Map res = retrieveMap("dns?arg=" + domain + "&r=" + recursive);
-        return (String)res.get("Path");
-    }
-
     public Map mount(java.io.File ipfsRoot, java.io.File ipnsRoot) throws IOException {
         if (ipfsRoot != null && !ipfsRoot.exists())
             ipfsRoot.mkdirs();

--- a/src/test/java/io/ipfs/api/APITest.java
+++ b/src/test/java/io/ipfs/api/APITest.java
@@ -735,12 +735,6 @@ public class APITest {
         String resolved = ipfs.name.resolve(Cid.decode((String) pub.get("Name")));
     }
 
-    @Test
-    public void dnsTest() throws IOException {
-        String domain = "ipfs.io";
-        String dns = ipfs.dns(domain, true);
-    }
-
     public void mountTest() throws IOException {
         Map mount = ipfs.mount(null, null);
     }


### PR DESCRIPTION
Because as per #237 this test does not work anymore, see:

```
dnsTest(io.ipfs.api.APITest)  Time elapsed: 0.002 sec  <<< ERROR!
java.lang.RuntimeException:
IOException contacting IPFS daemon.
404 page not found

Trailer: null
        at io.ipfs.api.APITest.dnsTest(APITest.java:741)
Caused by: java.io.FileNotFoundException: http://127.0.0.1:5001/api/v0/dns?arg=ipfs.io&r=true
        at io.ipfs.api.APITest.dnsTest(APITest.java:741)
```

And on https://docs.ipfs.tech/reference/kubo/rpc/ there does not (anymore) appear to be a `/api/v0/dns`.

@ianopolous merge?