### PR TITLE
fix: name resolve accepts any (resolvable) name

### DIFF
--- a/src/main/java/io/ipfs/api/IPFS.java
+++ b/src/main/java/io/ipfs/api/IPFS.java
@@ -625,6 +625,11 @@ public class IPFS {
             Map res = (Map) retrieveAndParse("name/resolve?arg=" + hash);
             return (String)res.get("Path");
         }
+
+        public String resolve(String name) throws IOException {
+            Map res = (Map) retrieveAndParse("name/resolve?arg=" + name);
+            return (String)res.get("Path");
+        }
     }
 
     public class DHT {


### PR DESCRIPTION
Not only hash.