### PR TITLE
Add jitpack.yml to signal need for Java 21

### DIFF
--- a/jitpack.yml
+++ b/jitpack.yml
@@ -1,0 +1,4 @@
+before_install:
+  - sdk install java 21-tem
+  - sdk use java 21-tem
+


### PR DESCRIPTION
For Maven wrapper, allegedly jitpack detects its presence and is not needed to install anything, will go for `./mvnw`.